### PR TITLE
Anpassung für 2025:  Diverse Aktualisierungen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # gpw2025
 
 Hier liegen HTML-Quellen für die Webseiten des German Perl/Raku Workshop 2025.
-Die Bedienungsanleitung liegt unter https://github.com/FrankfurtPM/GPW-Checklists/blob/master/ActKurzeinfuehrung.md.
+Die Bedienungsanleitung liegt unter https://github.com/FrankfurtPM/GPW-Checklists/wiki/ActKurzeinfuehrung.

--- a/actdocs/static/cfp.html
+++ b/actdocs/static/cfp.html
@@ -4,15 +4,19 @@
 <t>
  <de>
     <p>
-      Wo und wann der <em>
+      Der <em>
         <a href="https://act.yapc.eu/gpw2025/">Deutsche Perl/Raku-Workshop 2025</a></em>
-      stattfinden wird, steht noch nicht fest, aber es können schon Vortragsvorschläge eingereicht werden.
+      wird von 12. bis 14. Mai 2025 in München stattfinden.
+      Vortragsvorschläge sind herzlich willkommen!
     </p>
 
     <p>Wir freuen uns auf Vorschläge für Standardvorträge (20 oder 40 Minuten), Lightning Talks (5 Minuten)
     oder Workshops (2-4 Stunden). Vorschläge bitte über <a href="https://act.yapc.eu/gpw2025/newtalk">dieses Formular</a> einreichen.</p>
 
-    <p>Die Vorträge können z.B. folgende allgemeine Themen behandeln:
+    <p>Das diesjährige Hauptthema ist "Tickets for Today", aber neben
+    Vorträgen zu Ticketsystemen können auch gern andere Themen
+    vorgeschlagen werden. Hier ein paar Vorschläge:</p>
+
 <ul>
     <li>mit Perl/Raku verwandte Vorträge</li>
     <li>Software-Architektur</li>
@@ -30,15 +34,18 @@
   </de>
 
   <en>
-<p>The place and date of <a href="https://act.yapc.eu/gpw2025/"><em>German Perl and Software Engineering Workshop 2025</em></a> aren't determined, yet. But you can
-already submit your talk proposals.
+    <p>The <a href="https://act.yapc.eu/gpw2025/"><em>German Perl and Software Engineering Workshop 2025</em></a>
+
+      will take place May 12-14, 2025, in Munich.
+      Talk proposals are welcome!
 </p>
 
 <p>We are looking for your contribution in the form a talk (20 minutes or 40 minutes),
 a lighting talk (5 minutes) or a workshop (2-4 hours). Please submit your proposals
 <a href="https://act.yapc.eu/gpw2025/newtalk">using this online form</a>.</p>
 
-<p>Some examples of topics for your inspiration:</p>
+<p>This year's main topic is "Tickets for Today", but of course this
+is not exclusive. Some examples of topics for your inspiration:</p>
 <ul>
   <li>anything related to Perl/Raku</li>
   <li>software architecture</li>

--- a/actdocs/static/perl.html
+++ b/actdocs/static/perl.html
@@ -13,7 +13,7 @@
     <t>
       <de>
         <a href="https://perl.org/">Perl 5</a> wird seit 1987
-        weiterentwickelt, 2024 wird die Version 5.40 freigegeben. Perl 5
+        weiterentwickelt, 2025 wird die Version 5.42 freigegeben. Perl 5
         ist eine der meistgenutzten Programmiersprachen, läuft auf
         Plattformen vom Handy bis zum Mainframe und bietet mit dem
         "Comprehensive Perl Archive Network"
@@ -22,7 +22,7 @@
       </de>
       <en>
         <a href="https://perl.org/">Perl 5</a> is being developed
-        since 1987, version 5.40 will be released in 2024. Perl 5 is
+        since 1987, version 5.42 will be released in 2025. Perl 5 is
         one of the most popular languages and can be used on almost
         every platform between a mobile phone and a mainframe system.
         The "Comprehensive Perl Archive Network"

--- a/actdocs/templates/ui
+++ b/actdocs/templates/ui
@@ -33,6 +33,7 @@
                     <ul class="navbar-nav text-uppercase ml-auto">
                         <li class="nav-item"><a class="nav-link js-scroll-trigger" href="index.html">Workshop</a></li>
                         <li class="nav-item"><a class="nav-link js-scroll-trigger" href="index.html#news"><t><de>Neuigkeiten</de><en>News</en></t></a></li>
+                        <li class="nav-item"><a class="nav-link js-scroll-trigger" href="cfp.html"><t><de>CfP</de><en>CfP</en></t></a></li>
                         <!-- <li class="nav-item"><a class="nav-link js-scroll-trigger" href="[% make_uri('schedule') %]"><t><de>Programm</de><en>Schedule</en></t></a></li> -->
                         <!-- <li class="nav-item"><a class="nav-link js-scroll-trigger" href="[% make_uri('wiki') %]"><t><de>Wiki</de><en>Wiki</en></t></a></li> -->
                         <li class="nav-item"><a class="nav-link js-scroll-trigger" href="index.html#sponsors"><t><de>Sponsoren</de><en>Sponsors</en></t></a></li>
@@ -76,7 +77,7 @@
         <footer class="footer py-4">
             <div class="container">
                 <div class="row align-items-center">
-                    <div class="col-lg-4 text-lg-left">Copyright © perl-raku-workshop.de 2021 - 2024</div>
+                    <div class="col-lg-4 text-lg-left">Copyright © perl-raku-workshop.de 2021 - 2025</div>
                     <div class="col-lg-4 text-lg-right"><a class="mr-3" href="impressum.html"><t><de>Impressum und Datenschutzerklärung</de><en>Imprint and Data Protection</en></t></a></div>
                 </div>
             </div>


### PR DESCRIPTION
* README.md: Reparatur des Links zur Act-Anleitung.

* actdocs/templates/ui: CfP in die Navigation, Copyright bis 2025.

* actdocs/static/perl.html: Aktualisierung auf 2025 / Perl5.42.

* actdocs/static/cfp.html (Call for Presentations): Datum und Ort sowie Thema des GPW2025 stehen fest.